### PR TITLE
Add Chat Interface section to README with screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ curl -X POST http://localhost:5000/chat/stream \
 ![Model Catalog](docs/assets/model-all.png)
 *Browse and download from 31 pre-configured models organized by organization*
 
+### Chat Interface
+
+![Chat Interface](docs/assets/chat.png)
+*Chat with AI using streaming responses*
+
 ### RAG (Document Chat)
 
 ![RAG Document Chat](docs/assets/RAG.png)


### PR DESCRIPTION
Add Chat Interface section to README with screenshot

Added a new "Chat Interface" section to the README.md, including a screenshot and description to showcase the application's streaming chat capabilities. This section is placed between the "Model Catalog" and "RAG (Document Chat)" sections.