### PR TITLE
Add Vulkan backend, Arc detection, and upgrade LLamaSharp

### DIFF
--- a/KaiROS.AI/Converters/Converters.cs
+++ b/KaiROS.AI/Converters/Converters.cs
@@ -1,8 +1,9 @@
+using KaiROS.AI.Models;
+
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media.Imaging;
-using KaiROS.AI.Models;
 
 namespace KaiROS.AI.Converters;
 
@@ -86,7 +87,6 @@ public class BackendToStringConverter : IValueConverter
         {
             ExecutionBackend.Cpu => "CPU",
             ExecutionBackend.Cuda => "CUDA (NVIDIA)",
-            ExecutionBackend.DirectML => "DirectML (AMD/Intel)",
             ExecutionBackend.Npu => "NPU",
             ExecutionBackend.Auto => "Auto-detect",
             _ => "Unknown"

--- a/KaiROS.AI/Models/HardwareInfo.cs
+++ b/KaiROS.AI/Models/HardwareInfo.cs
@@ -8,22 +8,22 @@ public class HardwareInfo
     public List<ExecutionBackend> AvailableBackends { get; set; } = new();
     public ExecutionBackend RecommendedBackend { get; set; } = ExecutionBackend.Cpu;
     public ExecutionBackend SelectedBackend { get; set; } = ExecutionBackend.Cpu;
-    
+
     public long TotalRamBytes { get; set; }
     public long AvailableRamBytes { get; set; }
     public string TotalRamText => FormatBytes(TotalRamBytes);
     public string AvailableRamText => FormatBytes(AvailableRamBytes);
-    
+
     public string? GpuName { get; set; }
     public long GpuMemoryBytes { get; set; }
     public string GpuMemoryText => FormatBytes(GpuMemoryBytes);
-    
+
     public bool HasCuda { get; set; }
-    public bool HasDirectML { get; set; }
+    public bool HasVulkan { get; set; }
     public bool HasNpu { get; set; }
-    
+
     public string StatusMessage { get; set; } = string.Empty;
-    
+
     private static string FormatBytes(long bytes)
     {
         if (bytes <= 0) return "N/A";
@@ -43,7 +43,7 @@ public enum ExecutionBackend
 {
     Cpu,
     Cuda,
-    DirectML,
+    Vulkan,
     Npu,
     Auto
 }

--- a/KaiROS.AI/Package.appxmanifest
+++ b/KaiROS.AI/Package.appxmanifest
@@ -8,7 +8,7 @@
   <Identity
     Name="34488AvnishKumar.KaiROSAI"
     Publisher="CN=1494B4FB-4349-4083-8AFA-16D2A64B8D99"
-    Version="1.0.4.0" />
+    Version="1.0.6.0" />
 
   <Properties>
     <DisplayName>KaiROS AI</DisplayName>

--- a/KaiROS.AI/Services/DatabaseService.cs
+++ b/KaiROS.AI/Services/DatabaseService.cs
@@ -16,101 +16,131 @@ public class DatabaseService : IDatabaseService
 {
     private readonly string _dbPath;
     private readonly string _connectionString;
-    
+
     public DatabaseService()
     {
         var appDataPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "KaiROS.AI");
-        
+
         Directory.CreateDirectory(appDataPath);
         _dbPath = Path.Combine(appDataPath, "kairos.db");
         _connectionString = $"Data Source={_dbPath}";
     }
-    
+
     public async Task InitializeAsync()
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        
-        var command = connection.CreateCommand();
-        command.CommandText = @"
-            CREATE TABLE IF NOT EXISTS CustomModels (
-                Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                Name TEXT NOT NULL,
-                DisplayName TEXT NOT NULL,
-                Description TEXT,
-                FilePath TEXT,
-                DownloadUrl TEXT,
-                SizeBytes INTEGER DEFAULT 0,
-                AddedDate TEXT NOT NULL,
-                IsLocal INTEGER DEFAULT 0
-            )";
-        
-        await command.ExecuteNonQueryAsync();
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var command = connection.CreateCommand();
+            command.CommandText = @"
+                CREATE TABLE IF NOT EXISTS CustomModels (
+                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    Name TEXT NOT NULL,
+                    DisplayName TEXT NOT NULL,
+                    Description TEXT,
+                    FilePath TEXT,
+                    DownloadUrl TEXT,
+                    SizeBytes INTEGER DEFAULT 0,
+                    AddedDate TEXT NOT NULL,
+                    IsLocal INTEGER DEFAULT 0
+                )";
+
+            await command.ExecuteNonQueryAsync();
+        }
+        catch (SqliteException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[KaiROS] Database initialization error: {ex.Message}");
+            // Don't crash the app - custom models will just be unavailable
+        }
     }
-    
+
     public async Task<List<CustomModelEntity>> GetCustomModelsAsync()
     {
         var models = new List<CustomModelEntity>();
-        
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        
-        var command = connection.CreateCommand();
-        command.CommandText = "SELECT * FROM CustomModels ORDER BY AddedDate DESC";
-        
-        await using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+
+        try
         {
-            models.Add(new CustomModelEntity
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var command = connection.CreateCommand();
+            command.CommandText = "SELECT * FROM CustomModels ORDER BY AddedDate DESC";
+
+            await using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
             {
-                Id = reader.GetInt32(0),
-                Name = reader.GetString(1),
-                DisplayName = reader.GetString(2),
-                Description = reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
-                FilePath = reader.IsDBNull(4) ? string.Empty : reader.GetString(4),
-                DownloadUrl = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
-                SizeBytes = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
-                AddedDate = DateTime.Parse(reader.GetString(7)),
-                IsLocal = reader.GetInt32(8) == 1
-            });
+                models.Add(new CustomModelEntity
+                {
+                    Id = reader.GetInt32(0),
+                    Name = reader.GetString(1),
+                    DisplayName = reader.GetString(2),
+                    Description = reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+                    FilePath = reader.IsDBNull(4) ? string.Empty : reader.GetString(4),
+                    DownloadUrl = reader.IsDBNull(5) ? string.Empty : reader.GetString(5),
+                    SizeBytes = reader.IsDBNull(6) ? 0 : reader.GetInt64(6),
+                    AddedDate = DateTime.Parse(reader.GetString(7)),
+                    IsLocal = reader.GetInt32(8) == 1
+                });
+            }
         }
-        
+        catch (SqliteException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[KaiROS] Database read error: {ex.Message}");
+        }
+
         return models;
     }
-    
+
     public async Task AddCustomModelAsync(CustomModelEntity model)
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        
-        var command = connection.CreateCommand();
-        command.CommandText = @"
-            INSERT INTO CustomModels (Name, DisplayName, Description, FilePath, DownloadUrl, SizeBytes, AddedDate, IsLocal)
-            VALUES ($name, $displayName, $description, $filePath, $downloadUrl, $sizeBytes, $addedDate, $isLocal)";
-        
-        command.Parameters.AddWithValue("$name", model.Name);
-        command.Parameters.AddWithValue("$displayName", model.DisplayName);
-        command.Parameters.AddWithValue("$description", model.Description ?? string.Empty);
-        command.Parameters.AddWithValue("$filePath", model.FilePath ?? string.Empty);
-        command.Parameters.AddWithValue("$downloadUrl", model.DownloadUrl ?? string.Empty);
-        command.Parameters.AddWithValue("$sizeBytes", model.SizeBytes);
-        command.Parameters.AddWithValue("$addedDate", model.AddedDate.ToString("O"));
-        command.Parameters.AddWithValue("$isLocal", model.IsLocal ? 1 : 0);
-        
-        await command.ExecuteNonQueryAsync();
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var command = connection.CreateCommand();
+            command.CommandText = @"
+                INSERT INTO CustomModels (Name, DisplayName, Description, FilePath, DownloadUrl, SizeBytes, AddedDate, IsLocal)
+                VALUES ($name, $displayName, $description, $filePath, $downloadUrl, $sizeBytes, $addedDate, $isLocal)";
+
+            command.Parameters.AddWithValue("$name", model.Name);
+            command.Parameters.AddWithValue("$displayName", model.DisplayName);
+            command.Parameters.AddWithValue("$description", model.Description ?? string.Empty);
+            command.Parameters.AddWithValue("$filePath", model.FilePath ?? string.Empty);
+            command.Parameters.AddWithValue("$downloadUrl", model.DownloadUrl ?? string.Empty);
+            command.Parameters.AddWithValue("$sizeBytes", model.SizeBytes);
+            command.Parameters.AddWithValue("$addedDate", model.AddedDate.ToString("O"));
+            command.Parameters.AddWithValue("$isLocal", model.IsLocal ? 1 : 0);
+
+            await command.ExecuteNonQueryAsync();
+        }
+        catch (SqliteException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[KaiROS] Database write error: {ex.Message}");
+            throw new InvalidOperationException($"Failed to save model: Disk may be full. Please free up space and try again.", ex);
+        }
     }
-    
+
     public async Task DeleteCustomModelAsync(int id)
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync();
-        
-        var command = connection.CreateCommand();
-        command.CommandText = "DELETE FROM CustomModels WHERE Id = $id";
-        command.Parameters.AddWithValue("$id", id);
-        
-        await command.ExecuteNonQueryAsync();
+        try
+        {
+            await using var connection = new SqliteConnection(_connectionString);
+            await connection.OpenAsync();
+
+            var command = connection.CreateCommand();
+            command.CommandText = "DELETE FROM CustomModels WHERE Id = $id";
+            command.Parameters.AddWithValue("$id", id);
+
+            await command.ExecuteNonQueryAsync();
+        }
+        catch (SqliteException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[KaiROS] Database delete error: {ex.Message}");
+        }
     }
 }

--- a/KaiROS.AI/Services/ModelManagerService.cs
+++ b/KaiROS.AI/Services/ModelManagerService.cs
@@ -372,6 +372,7 @@ public class ModelManagerService : IModelManagerService
 
         // Get available VRAM in GB
         double vramGB = hardwareInfo.GpuMemoryBytes / (1024.0 * 1024.0 * 1024.0);
+        if (vramGB <= 0) vramGB = 0; // Don't assume VRAM if detection failed - fallback to CPU
 
         // Get model size in GB
         double modelSizeGB = model.SizeBytes / (1024.0 * 1024.0 * 1024.0);

--- a/KaiROS.AI/ViewModels/SettingsViewModel.cs
+++ b/KaiROS.AI/ViewModels/SettingsViewModel.cs
@@ -13,55 +13,55 @@ public partial class SettingsViewModel : ViewModelBase
     private readonly ChatViewModel _chatViewModel;
     private readonly IThemeService _themeService;
     private readonly IApiService _apiService;
-    
+
     private const string DefaultSystemPrompt = "You are a helpful, friendly AI assistant. Be concise and clear.";
-    
+
     [ObservableProperty]
     private HardwareInfo? _hardware;
-    
+
     [ObservableProperty]
     private ObservableCollection<ExecutionBackend> _availableBackends = new();
-    
+
     [ObservableProperty]
     private ExecutionBackend _selectedBackend;
-    
+
     [ObservableProperty]
     private string _modelsDirectory = string.Empty;
-    
+
     [ObservableProperty]
     private string _gpuInfo = "Detecting...";
-    
+
     [ObservableProperty]
     private string _ramInfo = "Detecting...";
-    
+
     [ObservableProperty]
     private string _backendStatus = string.Empty;
-    
+
     [ObservableProperty]
     private string _systemPrompt = DefaultSystemPrompt;
-    
+
     [ObservableProperty]
     private bool _isDarkTheme = true;
-    
+
     // API Settings
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ApiStatus))]
     [NotifyPropertyChangedFor(nameof(IsMinimizeToTrayEnabled))]
     private bool _isApiEnabled = false;
-    
+
     [ObservableProperty]
     private int _apiPort = 5000;
-    
+
     // API can only be enabled when a model is loaded
     public bool CanEnableApi => _modelManager.ActiveModel != null;
-    
+
     // System tray only enabled when API is running
     public bool IsMinimizeToTrayEnabled => IsApiEnabled && _apiService.IsRunning;
-    
-    public string ApiStatus => _apiService.IsRunning 
-        ? $"Running on http://localhost:{_apiService.Port}/" 
+
+    public string ApiStatus => _apiService.IsRunning
+        ? $"Running on http://localhost:{_apiService.Port}/"
         : CanEnableApi ? "Stopped (ready to start)" : "Disabled (load a model first)";
-    
+
     public SettingsViewModel(IHardwareDetectionService hardwareService, IModelManagerService modelManager, ChatViewModel chatViewModel, IThemeService themeService, IApiService apiService)
     {
         _hardwareService = hardwareService;
@@ -69,23 +69,23 @@ public partial class SettingsViewModel : ViewModelBase
         _chatViewModel = chatViewModel;
         _themeService = themeService;
         _apiService = apiService;
-        
+
         // Initialize system prompt from ChatViewModel
         _systemPrompt = chatViewModel.SystemPrompt;
-        
+
         // Initialize theme from service
         _isDarkTheme = _themeService.CurrentTheme == "Dark";
-        
+
         // Initialize API status
         _isApiEnabled = _apiService.IsRunning;
-        
+
         // Subscribe to model events to update CanEnableApi
-        _modelManager.ModelLoaded += (s, e) => 
+        _modelManager.ModelLoaded += (s, e) =>
         {
             OnPropertyChanged(nameof(CanEnableApi));
             OnPropertyChanged(nameof(ApiStatus));
         };
-        _modelManager.ModelUnloaded += (s, e) => 
+        _modelManager.ModelUnloaded += (s, e) =>
         {
             OnPropertyChanged(nameof(CanEnableApi));
             OnPropertyChanged(nameof(ApiStatus));
@@ -96,17 +96,17 @@ public partial class SettingsViewModel : ViewModelBase
             }
         };
     }
-    
+
     partial void OnSystemPromptChanged(string value)
     {
         // Sync to ChatViewModel
         _chatViewModel.SystemPrompt = value;
     }
-    
+
     partial void OnIsDarkThemeChanged(bool value)
     {
         _themeService.SetTheme(value ? "Dark" : "Light");
-        
+
         // Show message that restart is needed
         System.Windows.MessageBox.Show(
             "Theme preference saved. Please restart the application for the theme to take effect.",
@@ -114,7 +114,7 @@ public partial class SettingsViewModel : ViewModelBase
             System.Windows.MessageBoxButton.OK,
             System.Windows.MessageBoxImage.Information);
     }
-    
+
     async partial void OnIsApiEnabledChanged(bool value)
     {
         if (value)
@@ -128,30 +128,30 @@ public partial class SettingsViewModel : ViewModelBase
             OnPropertyChanged(nameof(ApiStatus));
         }
     }
-    
+
     public override async Task InitializeAsync()
     {
         IsLoading = true;
-        
+
         try
         {
             Hardware = await _hardwareService.DetectHardwareAsync();
-            
+
             AvailableBackends.Clear();
             foreach (var backend in Hardware.AvailableBackends)
             {
                 AvailableBackends.Add(backend);
             }
-            
+
             SelectedBackend = Hardware.SelectedBackend;
             ModelsDirectory = _modelManager.ModelsDirectory;
-            
-            GpuInfo = !string.IsNullOrEmpty(Hardware.GpuName) 
+
+            GpuInfo = !string.IsNullOrEmpty(Hardware.GpuName)
                 ? $"{Hardware.GpuName} ({Hardware.GpuMemoryText})"
                 : "No dedicated GPU detected";
-            
+
             RamInfo = $"{Hardware.TotalRamText} total, {Hardware.AvailableRamText} available";
-            
+
             UpdateBackendStatus();
         }
         finally
@@ -159,7 +159,7 @@ public partial class SettingsViewModel : ViewModelBase
             IsLoading = false;
         }
     }
-    
+
     partial void OnSelectedBackendChanged(ExecutionBackend value)
     {
         if (Hardware != null)
@@ -170,25 +170,25 @@ public partial class SettingsViewModel : ViewModelBase
             UpdateBackendStatus();
         }
     }
-    
+
     private void UpdateBackendStatus()
     {
         BackendStatus = SelectedBackend switch
         {
             ExecutionBackend.Cpu => "✓ CPU mode: Compatible with all systems. Slower but reliable.",
-            ExecutionBackend.Cuda => Hardware?.HasCuda == true 
-                ? "✓ CUDA: NVIDIA GPU acceleration enabled." 
+            ExecutionBackend.Cuda => Hardware?.HasCuda == true
+                ? "✓ CUDA: NVIDIA GPU acceleration enabled."
                 : "⚠ CUDA not available. Install CUDA toolkit.",
-            ExecutionBackend.DirectML => Hardware?.HasDirectML == true 
-                ? "✓ DirectML: Windows GPU acceleration enabled."
-                : "⚠ DirectML not available.",
-            ExecutionBackend.Npu => Hardware?.HasNpu == true 
+            ExecutionBackend.Vulkan => Hardware?.HasVulkan == true
+                ? "✓ Vulkan: High-performance GPU acceleration enabled (Best for Intel Arc/AMD)."
+                : "⚠ Vulkan not available.",
+            ExecutionBackend.Npu => Hardware?.HasNpu == true
                 ? "✓ NPU: Neural processing unit detected."
                 : "⚠ NPU not available on this system.",
             _ => "Select a backend"
         };
     }
-    
+
     [RelayCommand]
     private void BrowseModelsDirectory()
     {
@@ -196,14 +196,14 @@ public partial class SettingsViewModel : ViewModelBase
         {
             Title = "Select Models Directory"
         };
-        
+
         if (dialog.ShowDialog() == true)
         {
             ModelsDirectory = dialog.FolderName;
             _modelManager.SetModelsDirectory(dialog.FolderName);
         }
     }
-    
+
     [RelayCommand]
     private void UseRecommendedBackend()
     {
@@ -212,14 +212,14 @@ public partial class SettingsViewModel : ViewModelBase
             SelectedBackend = Hardware.RecommendedBackend;
         }
     }
-    
+
     [RelayCommand]
     private async Task RefreshHardwareInfo()
     {
         _hardwareService.ClearCache();
         await InitializeAsync();
     }
-    
+
     [RelayCommand]
     private void ResetSystemPrompt()
     {

--- a/KaiROS.AI/Views/ModelCatalogView.xaml
+++ b/KaiROS.AI/Views/ModelCatalogView.xaml
@@ -202,6 +202,10 @@
                                                         <Run Text="💾"/><Run Text="{Binding Model.SizeText}"/>
                                                     </TextBlock>
                                                 </StackPanel>
+                                                <!-- Error Message -->
+                                                <TextBlock Text="{Binding ErrorMessage}" Foreground="{StaticResource ErrorBrush}" 
+                                                         FontSize="12" Margin="0,8,0,0" TextWrapping="Wrap"
+                                                         Visibility="{Binding ErrorMessage, Converter={StaticResource BoolToVis}}"/>
                                             </StackPanel>
                                             
                                             <StackPanel Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal" Margin="20,0,0,0">
@@ -330,6 +334,11 @@
                                                             <TextBlock Text="{Binding DownloadProgress, StringFormat={}{0:F1}%}" HorizontalAlignment="Right"
                                                                        Margin="0,10,0,0" FontSize="12" Foreground="{StaticResource TextSecondaryBrush}"/>
                                                         </Grid>
+
+                                                        <!-- Error Message -->
+                                                        <TextBlock Text="{Binding ErrorMessage}" Foreground="{StaticResource ErrorBrush}" 
+                                                                 FontSize="12" Margin="0,8,0,0" TextWrapping="Wrap"
+                                                                 Visibility="{Binding ErrorMessage, Converter={StaticResource BoolToVis}}"/>
                                                     </StackPanel>
                                                     
                                                     <StackPanel Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal" Margin="20,0,0,0">

--- a/KaiROS.AI/appsettings.json
+++ b/KaiROS.AI/appsettings.json
@@ -372,22 +372,22 @@
             "Family": "Llama",
             "Variant": "All"
         },
-        {
-            "Name": "ggml-model-i2_s.gguf",
-            "DisplayName": "BitNet b1.58 2B",
-            "Description": "Microsoft\u0027s revolutionary 1-bit quantized model. Extremely efficient CPU inference with minimal memory.",
-            "SizeText": "0.5 GB",
-            "SizeBytes": 536870912,
-            "DownloadUrl": "https://huggingface.co/microsoft/bitnet-b1.58-2B-4T-gguf/resolve/main/ggml-model-i2_s.gguf",
-            "Capabilities": "1-Bit • Ultra Efficient • CPU Optimized",
-            "MinRam": "2 GB",
-            "Category": "small",
-            "IsRecommended": true,
-            "Organization": "Microsoft",
-            "OrgLogoUrl": "https://avatars.githubusercontent.com/u/6154722",
-            "Family": "BitNet",
-            "Variant": "CPU-Only"
-        },
+        // {
+        //     "Name": "ggml-model-i2_s.gguf",
+        //     "DisplayName": "BitNet b1.58 2B",
+        //     "Description": "Microsoft\u0027s revolutionary 1-bit quantized model. Extremely efficient CPU inference with minimal memory.",
+        //     "SizeText": "0.5 GB",
+        //     "SizeBytes": 536870912,
+        //     "DownloadUrl": "https://huggingface.co/microsoft/bitnet-b1.58-2B-4T-gguf/resolve/main/ggml-model-i2_s.gguf",
+        //     "Capabilities": "1-Bit • Ultra Efficient • CPU Optimized",
+        //     "MinRam": "2 GB",
+        //     "Category": "small",
+        //     "IsRecommended": true,
+        //     "Organization": "Microsoft",
+        //     "OrgLogoUrl": "https://avatars.githubusercontent.com/u/6154722",
+        //     "Family": "BitNet",
+        //     "Variant": "CPU-Only"
+        // },
         {
             "Name": "phi-2.Q4_K_M.gguf",
             "DisplayName": "Phi-2 2.7B",

--- a/KaiROS.AI/msix-publish/AppxManifest.xml
+++ b/KaiROS.AI/msix-publish/AppxManifest.xml
@@ -8,7 +8,7 @@
   <Identity
     Name="34488AvnishKumar.KaiROSAI"
     Publisher="CN=1494B4FB-4349-4083-8AFA-16D2A64B8D99"
-    Version="1.0.4.0" />
+    Version="1.0.5.0" />
 
   <Properties>
     <DisplayName>KaiROS AI</DisplayName>

--- a/KaiROS.AI/msix-publish/KaiROS.AI.deps.json
+++ b/KaiROS.AI/msix-publish/KaiROS.AI.deps.json
@@ -12,8 +12,10 @@
           "CommunityToolkit.Mvvm": "8.4.0",
           "DocumentFormat.OpenXml": "3.3.0",
           "Hardcodet.NotifyIcon.Wpf": "1.1.0",
-          "LLamaSharp": "0.19.0",
-          "LLamaSharp.Backend.Cpu": "0.19.0",
+          "LLamaSharp": "0.25.0",
+          "LLamaSharp.Backend.Cpu": "0.25.0",
+          "LLamaSharp.Backend.Cuda12": "0.25.0",
+          "LLamaSharp.Backend.Vulkan": "0.25.0",
           "Microsoft.Data.Sqlite": "10.0.1",
           "Microsoft.Extensions.Configuration.Json": "9.0.0",
           "Microsoft.Extensions.DependencyInjection": "9.0.0",
@@ -1004,6 +1006,14 @@
           }
         }
       },
+      "CommunityToolkit.HighPerformance/8.4.0": {
+        "runtime": {
+          "lib/net8.0/CommunityToolkit.HighPerformance.dll": {
+            "assemblyVersion": "8.4.0.0",
+            "fileVersion": "8.4.0.1"
+          }
+        }
+      },
       "CommunityToolkit.Mvvm/8.4.0": {
         "runtime": {
           "lib/net8.0-windows10.0.17763/CommunityToolkit.Mvvm.dll": {
@@ -1110,12 +1120,13 @@
           "itext": "8.0.5"
         }
       },
-      "LLamaSharp/0.19.0": {
+      "LLamaSharp/0.25.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.Extensions.AI.Abstractions": "9.0.0-preview.9.24525.1",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
-          "System.Numerics.Tensors": "8.0.0"
+          "CommunityToolkit.HighPerformance": "8.4.0",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.8",
+          "Microsoft.Extensions.AI.Abstractions": "9.7.1",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8",
+          "System.Numerics.Tensors": "9.0.8"
         },
         "runtime": {
           "lib/net8.0/LLamaSharp.dll": {
@@ -1124,15 +1135,27 @@
           }
         }
       },
-      "LLamaSharp.Backend.Cpu/0.19.0": {
+      "LLamaSharp.Backend.Cpu/0.25.0": {
         "native": {
+          "runtimes/win-x64/native/avx/ggml-base.dll": {
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/avx/ggml-cpu.dll": {
+            "fileVersion": "0.0.0.0"
+          },
           "runtimes/win-x64/native/avx/ggml.dll": {
             "fileVersion": "0.0.0.0"
           },
           "runtimes/win-x64/native/avx/llama.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/avx/llava_shared.dll": {
+          "runtimes/win-x64/native/avx/mtmd.dll": {
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/avx2/ggml-base.dll": {
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/avx2/ggml-cpu.dll": {
             "fileVersion": "0.0.0.0"
           },
           "runtimes/win-x64/native/avx2/ggml.dll": {
@@ -1141,7 +1164,13 @@
           "runtimes/win-x64/native/avx2/llama.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/avx2/llava_shared.dll": {
+          "runtimes/win-x64/native/avx2/mtmd.dll": {
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/avx512/ggml-base.dll": {
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/avx512/ggml-cpu.dll": {
             "fileVersion": "0.0.0.0"
           },
           "runtimes/win-x64/native/avx512/ggml.dll": {
@@ -1150,25 +1179,61 @@
           "runtimes/win-x64/native/avx512/llama.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/avx512/llava_shared.dll": {
+          "runtimes/win-x64/native/avx512/mtmd.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/ggml.dll": {
+          "runtimes/win-x64/native/noavx/ggml-base.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/llama.dll": {
+          "runtimes/win-x64/native/noavx/ggml-cpu.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/llava_shared.dll": {
+          "runtimes/win-x64/native/noavx/ggml.dll": {
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/noavx/llama.dll": {
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/noavx/mtmd.dll": {
             "fileVersion": "0.0.0.0"
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+      "LLamaSharp.Backend.Cuda12/0.25.0": {
+        "dependencies": {
+          "LLamaSharp.Backend.Cuda12.Windows": "0.25.0"
+        }
+      },
+      "LLamaSharp.Backend.Cuda12.Windows/0.25.0": {
+        "dependencies": {
+          "LLamaSharp.Backend.Cpu": "0.25.0"
+        },
+        "native": {
+          "runtimes/win-x64/native/cuda12/ggml-cuda.dll": {
+            "fileVersion": "0.0.0.0"
+          }
+        }
+      },
+      "LLamaSharp.Backend.Vulkan/0.25.0": {
+        "dependencies": {
+          "LLamaSharp.Backend.Vulkan.Windows": "0.25.0"
+        }
+      },
+      "LLamaSharp.Backend.Vulkan.Windows/0.25.0": {
+        "dependencies": {
+          "LLamaSharp.Backend.Cpu": "0.25.0"
+        },
+        "native": {
+          "runtimes/win-x64/native/vulkan/ggml-vulkan.dll": {
+            "fileVersion": "0.0.0.0"
+          }
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces/9.0.8": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "assemblyVersion": "9.0.0.8",
+            "fileVersion": "9.0.825.36511"
           }
         }
       },
@@ -1198,11 +1263,11 @@
           }
         }
       },
-      "Microsoft.Extensions.AI.Abstractions/9.0.0-preview.9.24525.1": {
+      "Microsoft.Extensions.AI.Abstractions/9.7.1": {
         "runtime": {
           "lib/net9.0/Microsoft.Extensions.AI.Abstractions.dll": {
-            "assemblyVersion": "9.0.0.0",
-            "fileVersion": "9.0.24.52501"
+            "assemblyVersion": "9.7.0.0",
+            "fileVersion": "9.700.125.36504"
           }
         }
       },
@@ -1309,7 +1374,7 @@
       },
       "Microsoft.Extensions.DependencyInjection/9.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8"
         },
         "runtime": {
           "lib/net9.0/Microsoft.Extensions.DependencyInjection.dll": {
@@ -1318,11 +1383,11 @@
           }
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.0": {
+      "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.8": {
         "runtime": {
           "lib/net9.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
             "assemblyVersion": "9.0.0.0",
-            "fileVersion": "9.0.24.52809"
+            "fileVersion": "9.0.825.36511"
           }
         }
       },
@@ -1353,7 +1418,7 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions/9.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Options": "9.0.0"
         },
         "runtime": {
@@ -1406,13 +1471,13 @@
           "Microsoft.Extensions.Configuration.Json": "9.0.0",
           "Microsoft.Extensions.Configuration.UserSecrets": "9.0.0",
           "Microsoft.Extensions.DependencyInjection": "9.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Diagnostics": "9.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "9.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "9.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "9.0.0",
           "Microsoft.Extensions.Logging": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8",
           "Microsoft.Extensions.Logging.Configuration": "9.0.0",
           "Microsoft.Extensions.Logging.Console": "9.0.0",
           "Microsoft.Extensions.Logging.Debug": "9.0.0",
@@ -1430,10 +1495,10 @@
       "Microsoft.Extensions.Hosting.Abstractions/9.0.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "9.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8"
         },
         "runtime": {
           "lib/net9.0/Microsoft.Extensions.Hosting.Abstractions.dll": {
@@ -1445,7 +1510,7 @@
       "Microsoft.Extensions.Logging/9.0.0": {
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8",
           "Microsoft.Extensions.Options": "9.0.0"
         },
         "runtime": {
@@ -1455,14 +1520,14 @@
           }
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions/9.0.0": {
+      "Microsoft.Extensions.Logging.Abstractions/9.0.8": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8"
         },
         "runtime": {
           "lib/net9.0/Microsoft.Extensions.Logging.Abstractions.dll": {
             "assemblyVersion": "9.0.0.0",
-            "fileVersion": "9.0.24.52809"
+            "fileVersion": "9.0.825.36511"
           }
         }
       },
@@ -1471,9 +1536,9 @@
           "Microsoft.Extensions.Configuration": "9.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "9.0.0",
           "Microsoft.Extensions.Configuration.Binder": "9.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Logging": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8",
           "Microsoft.Extensions.Options": "9.0.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.0"
         },
@@ -1486,9 +1551,9 @@
       },
       "Microsoft.Extensions.Logging.Console/9.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Logging": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8",
           "Microsoft.Extensions.Logging.Configuration": "9.0.0",
           "Microsoft.Extensions.Options": "9.0.0"
         },
@@ -1501,9 +1566,9 @@
       },
       "Microsoft.Extensions.Logging.Debug/9.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Logging": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8"
         },
         "runtime": {
           "lib/net9.0/Microsoft.Extensions.Logging.Debug.dll": {
@@ -1514,9 +1579,9 @@
       },
       "Microsoft.Extensions.Logging.EventLog/9.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Logging": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8",
           "Microsoft.Extensions.Options": "9.0.0"
         },
         "runtime": {
@@ -1528,9 +1593,9 @@
       },
       "Microsoft.Extensions.Logging.EventSource/9.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Logging": "9.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.8",
           "Microsoft.Extensions.Options": "9.0.0",
           "Microsoft.Extensions.Primitives": "9.0.0"
         },
@@ -1543,7 +1608,7 @@
       },
       "Microsoft.Extensions.Options/9.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Primitives": "9.0.0"
         },
         "runtime": {
@@ -1557,7 +1622,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "9.0.0",
           "Microsoft.Extensions.Configuration.Binder": "9.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Options": "9.0.0",
           "Microsoft.Extensions.Primitives": "9.0.0"
         },
@@ -1630,11 +1695,11 @@
           }
         }
       },
-      "System.Numerics.Tensors/8.0.0": {
+      "System.Numerics.Tensors/9.0.8": {
         "runtime": {
-          "lib/net8.0/System.Numerics.Tensors.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+          "lib/net9.0/System.Numerics.Tensors.dll": {
+            "assemblyVersion": "9.0.0.8",
+            "fileVersion": "9.0.825.36511"
           }
         }
       }
@@ -1660,6 +1725,13 @@
       "type": "runtimepack",
       "serviceable": false,
       "sha512": ""
+    },
+    "CommunityToolkit.HighPerformance/8.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg==",
+      "path": "communitytoolkit.highperformance/8.4.0",
+      "hashPath": "communitytoolkit.highperformance.8.4.0.nupkg.sha512"
     },
     "CommunityToolkit.Mvvm/8.4.0": {
       "type": "package",
@@ -1710,26 +1782,54 @@
       "path": "itext7/8.0.5",
       "hashPath": "itext7.8.0.5.nupkg.sha512"
     },
-    "LLamaSharp/0.19.0": {
+    "LLamaSharp/0.25.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lfFrPHVNe6AVRascLBNc6m8g5Rj4vGJvcOo2Zg/3GFUrNBsDOh4fyI2kJ94UDiDEvJ1OFnhExff7W7aYngzqdw==",
-      "path": "llamasharp/0.19.0",
-      "hashPath": "llamasharp.0.19.0.nupkg.sha512"
+      "sha512": "sha512-7xX6WOLd8ylbFziLTVSUJ35OV0ti7HYQ37olK/ib3tSUr1SRqncqBaCpZFYenkMNdbQVUDrWdTr/nX+OaYohyw==",
+      "path": "llamasharp/0.25.0",
+      "hashPath": "llamasharp.0.25.0.nupkg.sha512"
     },
-    "LLamaSharp.Backend.Cpu/0.19.0": {
+    "LLamaSharp.Backend.Cpu/0.25.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zG6xQCE2072MDqAgXRgyXXe2hWws4y6r40vU/vuxLzzYUXTyQwypPCpm+ZHuFJqL3YmZ9SNOzPFo3LnN7bDNKA==",
-      "path": "llamasharp.backend.cpu/0.19.0",
-      "hashPath": "llamasharp.backend.cpu.0.19.0.nupkg.sha512"
+      "sha512": "sha512-z8AGddGm0w3bdpDkEDjA6sdEK8ScsJCl42cGQ1jVCKXMhwQEoEGP4Vv20Vroeh3Li7Ny8azcz/wxF9BGJrmdSg==",
+      "path": "llamasharp.backend.cpu/0.25.0",
+      "hashPath": "llamasharp.backend.cpu.0.25.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+    "LLamaSharp.Backend.Cuda12/0.25.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
-      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
+      "sha512": "sha512-dTfn9WdiLJIjzKeqLd+tdXWrAc7pvgWie0hcy0YHs+FQD6S/p3Pwt1z2OC1vO+i8smKSTPqNsZA1Y5r6iue/yg==",
+      "path": "llamasharp.backend.cuda12/0.25.0",
+      "hashPath": "llamasharp.backend.cuda12.0.25.0.nupkg.sha512"
+    },
+    "LLamaSharp.Backend.Cuda12.Windows/0.25.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PdwOfO2i49uu8iYVqPHzvYgpCZ0/mRQhoXFOd1dpUUyMyYR23Vtif/tsajFWFqO+5mC230Fz/7/Ubs6BDb1DDA==",
+      "path": "llamasharp.backend.cuda12.windows/0.25.0",
+      "hashPath": "llamasharp.backend.cuda12.windows.0.25.0.nupkg.sha512"
+    },
+    "LLamaSharp.Backend.Vulkan/0.25.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-oMxiHZ7il8qjYXuNVq2Qn5MB/uRTos0xuD4eKeA2swPjnuVZbgGV5a3Uwd5ZKOrIJVq7OfwM0jeKW8fkahZENg==",
+      "path": "llamasharp.backend.vulkan/0.25.0",
+      "hashPath": "llamasharp.backend.vulkan.0.25.0.nupkg.sha512"
+    },
+    "LLamaSharp.Backend.Vulkan.Windows/0.25.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-VYcl4F/0xAl78ig6cIKQPwxg9/aj1nZLJEU7qGEvC0MLsh1ssXxzKDbacV2dHnRVLy+A+6dUcuSxy7oP1H/Z+Q==",
+      "path": "llamasharp.backend.vulkan.windows/0.25.0",
+      "hashPath": "llamasharp.backend.vulkan.windows.0.25.0.nupkg.sha512"
+    },
+    "Microsoft.Bcl.AsyncInterfaces/9.0.8": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-mdq9WaHnRJBvmhbDvoEk9aIEjpoW1cmA6wGuE0/eV49NT/0Z/d+NauB4jzw2Dyi/TndebYfjAYHCOXeB0c/Qhg==",
+      "path": "microsoft.bcl.asyncinterfaces/9.0.8",
+      "hashPath": "microsoft.bcl.asyncinterfaces.9.0.8.nupkg.sha512"
     },
     "Microsoft.Data.Sqlite/10.0.1": {
       "type": "package",
@@ -1752,12 +1852,12 @@
       "path": "microsoft.dotnet.platformabstractions/1.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.1.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.AI.Abstractions/9.0.0-preview.9.24525.1": {
+    "Microsoft.Extensions.AI.Abstractions/9.7.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-b5EntLa7aYjui129KSWQRZpXgUNn6l5G9OYQwVFlDXPiADMcmMEJCveD3BDBDxSbt1jkhIYs0eGuYKM0mXVkFw==",
-      "path": "microsoft.extensions.ai.abstractions/9.0.0-preview.9.24525.1",
-      "hashPath": "microsoft.extensions.ai.abstractions.9.0.0-preview.9.24525.1.nupkg.sha512"
+      "sha512": "sha512-fcAMMDxGgdl7vgkiFQ2yojdEwvGIkIpxsv6SQ33enA+q2iGuv3jsFUZmq6ZJ0YvMgrce7mG6GHFkEVcNxjIl0A==",
+      "path": "microsoft.extensions.ai.abstractions/9.7.1",
+      "hashPath": "microsoft.extensions.ai.abstractions.9.7.1.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/9.0.0": {
       "type": "package",
@@ -1822,12 +1922,12 @@
       "path": "microsoft.extensions.dependencyinjection/9.0.0",
       "hashPath": "microsoft.extensions.dependencyinjection.9.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.8": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+6f2qv2a3dLwd5w6JanPIPs47CxRbnk+ZocMJUhv9NxP88VlOcJYZs9jY+MYSjxvady08bUZn6qgiNh7DadGgg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/9.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.9.0.0.nupkg.sha512"
+      "sha512": "sha512-xY3lTjj4+ZYmiKIkyWitddrp1uL5uYiweQjqo4BKBw01ZC4HhcfgLghDpPZcUlppgWAFqFy9SgkiYWOMx365pw==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/9.0.8",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.9.0.8.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/1.1.0": {
       "type": "package",
@@ -1892,12 +1992,12 @@
       "path": "microsoft.extensions.logging/9.0.0",
       "hashPath": "microsoft.extensions.logging.9.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging.Abstractions/9.0.0": {
+    "Microsoft.Extensions.Logging.Abstractions/9.0.8": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-g0UfujELzlLbHoVG8kPKVBaW470Ewi+jnptGS9KUi6jcb+k2StujtK3m26DFSGGwQ/+bVgZfsWqNzlP6YOejvw==",
-      "path": "microsoft.extensions.logging.abstractions/9.0.0",
-      "hashPath": "microsoft.extensions.logging.abstractions.9.0.0.nupkg.sha512"
+      "sha512": "sha512-pYnAffJL7ARD/HCnnPvnFKSIHnTSmWz84WIlT9tPeQ4lHNiu0Az7N/8itihWvcF8sT+VVD5lq8V+ckMzu4SbOw==",
+      "path": "microsoft.extensions.logging.abstractions/9.0.8",
+      "hashPath": "microsoft.extensions.logging.abstractions.9.0.8.nupkg.sha512"
     },
     "Microsoft.Extensions.Logging.Configuration/9.0.0": {
       "type": "package",
@@ -1997,12 +2097,12 @@
       "path": "system.management/9.0.0",
       "hashPath": "system.management.9.0.0.nupkg.sha512"
     },
-    "System.Numerics.Tensors/8.0.0": {
+    "System.Numerics.Tensors/9.0.8": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-fhODzTe9ON9IzmRfyVeA6L8yXOciMtpq1YufkRVBliggcVKZE+XDxqIn46+yF4PWR6wNPuDpXtPpuY86VcKxUA==",
-      "path": "system.numerics.tensors/8.0.0",
-      "hashPath": "system.numerics.tensors.8.0.0.nupkg.sha512"
+      "sha512": "sha512-vnT3XBwytt8pYM25+lEHzR19F4GTkA9YA1E6wLOb55fiyY0wIaTVhlLrWAurvXcsgUdtNn0Ihw4qwWlsK6Wljg==",
+      "path": "system.numerics.tensors/9.0.8",
+      "hashPath": "system.numerics.tensors.9.0.8.nupkg.sha512"
     }
   },
   "runtimes": {

--- a/KaiROS.AI/msix-publish/appsettings.json
+++ b/KaiROS.AI/msix-publish/appsettings.json
@@ -7,7 +7,7 @@
         {
             "Name": "Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
             "DisplayName": "Qwen 2.5 0.5B",
-            "Description": "Alibaba\u0027s ultra-compact instruction model. Extremely fast for basic tasks.",
+            "Description": "Qwen\u0027s ultra-compact instruction model. Extremely fast for basic tasks.",
             "SizeText": "0.4 GB",
             "SizeBytes": 429916160,
             "DownloadUrl": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf",
@@ -15,7 +15,7 @@
             "MinRam": "1 GB",
             "Category": "small",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"
@@ -23,7 +23,7 @@
         {
             "Name": "Qwen2.5-1.5B-Instruct-Q4_K_M.gguf",
             "DisplayName": "Qwen 2.5 1.5B",
-            "Description": "Alibaba\u0027s compact instruction model with excellent multilingual support.",
+            "Description": "Qwen\u0027s compact instruction model with excellent multilingual support.",
             "SizeText": "1.0 GB",
             "SizeBytes": 1073741824,
             "DownloadUrl": "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf",
@@ -31,7 +31,7 @@
             "MinRam": "3 GB",
             "Category": "small",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"
@@ -39,7 +39,7 @@
         {
             "Name": "Qwen2.5-14B-Instruct-Q4_K_M.gguf",
             "DisplayName": "Qwen 2.5 14B",
-            "Description": "Alibaba\u0027s large model with exceptional reasoning and multilingual capabilities.",
+            "Description": "Qwen\u0027s large model with exceptional reasoning and multilingual capabilities.",
             "SizeText": "9.0 GB",
             "SizeBytes": 9663676416,
             "DownloadUrl": "https://huggingface.co/bartowski/Qwen2.5-14B-Instruct-GGUF/resolve/main/Qwen2.5-14B-Instruct-Q4_K_M.gguf",
@@ -47,7 +47,7 @@
             "MinRam": "16 GB",
             "Category": "large",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "GPU-Recommended"
@@ -55,7 +55,7 @@
         {
             "Name": "Qwen2.5-3B-Instruct-Q4_K_M.gguf",
             "DisplayName": "Qwen 2.5 3B",
-            "Description": "Alibaba\u0027s efficient 3B model with strong coding and reasoning capabilities.",
+            "Description": "Qwen\u0027s efficient 3B model with strong coding and reasoning capabilities.",
             "SizeText": "2.0 GB",
             "SizeBytes": 2147483648,
             "DownloadUrl": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/main/qwen2.5-3b-instruct-q4_k_m.gguf",
@@ -63,7 +63,7 @@
             "MinRam": "4 GB",
             "Category": "small",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"
@@ -71,7 +71,7 @@
         {
             "Name": "Qwen2.5-7B-Instruct-Q4_K_M.gguf",
             "DisplayName": "Qwen 2.5 7B",
-            "Description": "Alibaba\u0027s capable 7B model with excellent multilingual and coding abilities.",
+            "Description": "Qwen\u0027s capable 7B model with excellent multilingual and coding abilities.",
             "SizeText": "4.5 GB",
             "SizeBytes": 4831838208,
             "DownloadUrl": "https://huggingface.co/bartowski/Qwen2.5-7B-Instruct-GGUF/resolve/main/Qwen2.5-7B-Instruct-Q4_K_M.gguf",
@@ -79,7 +79,7 @@
             "MinRam": "8 GB",
             "Category": "medium",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"
@@ -87,7 +87,7 @@
         {
             "Name": "Qwen2.5-Coder-0.5B-Instruct-Q8_0.gguf",
             "DisplayName": "Qwen 2.5 Coder 0.5B",
-            "Description": "Alibaba\u0027s tiny coding assistant. Perfect for code completion on CPU.",
+            "Description": "Qwen\u0027s tiny coding assistant. Perfect for code completion on CPU.",
             "SizeText": "0.5 GB",
             "SizeBytes": 536870912,
             "DownloadUrl": "https://huggingface.co/Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF/resolve/main/qwen2.5-coder-0.5b-instruct-q8_0.gguf",
@@ -95,7 +95,7 @@
             "MinRam": "1 GB",
             "Category": "small",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "CPU-Only"
@@ -111,7 +111,7 @@
             "MinRam": "2 GB",
             "Category": "small",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"
@@ -127,7 +127,7 @@
             "MinRam": "3 GB",
             "Category": "small",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"
@@ -143,7 +143,7 @@
             "MinRam": "6 GB",
             "Category": "small",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"
@@ -159,7 +159,7 @@
             "MinRam": "10 GB",
             "Category": "medium",
             "IsRecommended": false,
-            "Organization": "Alibaba",
+            "Organization": "Qwen",
             "OrgLogoUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/250px-Qwen_logo.svg.png",
             "Family": "Qwen",
             "Variant": "All"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ### Advanced
 
-- �🔌 **Local REST API** - OpenAI-compatible API server for integration
+- �🔌 **Local REST API** - Built-in REST API server for integration
   - Endpoints: `/health`, `/models`, `/chat`, `/chat/stream`
   - Works with VS Code Continue, LM Studio clients, curl
 - 🗔 **System Tray** - Minimize to tray when API is running
@@ -182,7 +182,7 @@ curl -X POST http://localhost:5000/chat/stream \
 | **Meta** | 4 | LLaMA 3.1/3.2 + TinyLlama |
 | **Microsoft** | 3 | Phi-2, Phi-3, BitNet b1.58 |
 | **MistralAI** | 2 | Mistral 7B, Mistral Small 24B |
-| **OpenAI** | 1 | GPT-oss 20B ⚠️ Experimental |
+| **Open Source** | 1 | GPT-oss 20B ⚠️ Experimental |
 | **RWKV** | 1 | RWKV-7 0.1B - Linear complexity RNN |
 | **Stability AI** | 1 | StableLM Zephyr 3B |
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,20 +3,25 @@
 ## 🚀 New Features
 
 ### Custom Model Support
+
 - ➕ Add your own `.gguf` models from local files or download URLs
 - 📦 SQLite database stores custom model entries persistently
 - 🗑️ Delete custom models with one click
 
-### Execution Backend Selection (Now Working!)
-- 🎛️ Choose between CPU, CUDA, DirectML, or NPU in Settings
-- ✅ Selection now properly applies when loading models
-- 📊 Loading text shows actual selected backend
+### Intel Arc & Vulkan Support
+
+- 🎮 **Added Vulkan Backend**: High-performance acceleration specifically for Intel Arc and AMD GPUs.
+- 🛠️ **Cross-Platform Stability**: Vulkan provides better compatibility than DirectML for universal Windows GPU support.
+- 📏 **Arc VRAM Detection**: Correctly identifies VRAM for Intel Arc A770, A750, and other models.
+- 📊 **Improved Status Bar**: Clearer hardware info with unified backend status.
 
 ### API Mode Enhancements
+
 - 🌐 Added `internetClient` and `internetClientServer` capabilities
 - 🔌 Improved API stability
 
 ### RAG Document Support
+
 - 📄 Enhanced debug logging for document loading
 - 🔍 Better context retrieval tracking
 - 📝 Support for PDF, Word, and text files


### PR DESCRIPTION
- Add Vulkan backend for Intel Arc/AMD GPU acceleration; remove DirectML
- Upgrade LLamaSharp and backends to v0.25.0 (Vulkan, CUDA12)
- Improve hardware detection, especially for Intel Arc VRAM
- Update UI: unified backend status, error messages in catalog
- Refine model catalog org grouping (Meta, Microsoft, Google first)
- Update Qwen model orgs/descriptions; comment out BitNet 2B
- Improve DB error handling for custom models
- Bump dependency versions for .NET 8/9 compatibility
- Update manifests, README, and release notes for new features